### PR TITLE
Converting getFunctionsController to typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "LambdaLens",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/server/configs/awsconfig.ts
+++ b/server/configs/awsconfig.ts
@@ -1,0 +1,16 @@
+import { Config } from '../types.js' 
+import dotenv from 'dotenv';
+import path from 'path';
+
+// Load environment variables
+dotenv.config({ path: path.resolve(__dirname, '../.env')});
+
+//typescript recognizes process.env as undefined
+//use ! to signify that it's NOT null even though it looks like it 
+export const awsconfig: Config = {
+    credentials: {
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+    },
+    region: process.env.AWS_REGION!,
+};

--- a/server/controllers/getFunctionsController.ts
+++ b/server/controllers/getFunctionsController.ts
@@ -1,59 +1,38 @@
 import { LambdaClient, ListFunctionsCommand } from '@aws-sdk/client-lambda';
-import dotenv from 'dotenv';
-import path from 'path';
-// import { Config } from '../../types.ts' 
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+import { awsconfig } from '../configs/awsconfig';
 
-// Load environment variables
-dotenv.config({ path: path.resolve(__dirname, '../.env')});
-
-//I still need to put this Config interface into a types.ts and import it, also need to not use ?
-interface Config {
-    credentials: {
-      accessKeyId?: string;
-      secretAccessKey?: string;
-    };
-    region?: string;
-  };
-
-const config: Config = {
-    credentials: {
-      accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-    },
-    region: process.env.AWS_REGION,
-};
-
-  
-
-const lambdaClient = new LambdaClient(config);
+interface GetFunctionsController {
+  listFunctionData: RequestHandler;
+}
 
 // Function to list all Lambda functions
-export const getFunctions = async () => {
+export const getFunctionsController: GetFunctionsController = {
+  
+  listFunctionData: async (
+    _req: Request, 
+    res: Response, 
+    next: NextFunction): 
+    Promise<void> => {
+    const lambdaClient = new LambdaClient(awsconfig);
+
     const command = new ListFunctionsCommand({});
     try {
-      //send the ListFunctions command to the Lambda Client
-      const data = await lambdaClient.send(command);
-    //   console.log(data);
+        const data = await lambdaClient.send(command);
+        const funcObjectArray:any = await data.Functions;   //probably not best practice to use any but each object is very large
+        // console.log('funcObjectArray: ', funcObjectArray);
 
-      //funcObjectArray contains keys we can use such as 
-      //FunctionName, MemorySize, Timeout, and CodeSize
-      const funcObjectArray: any = await data.Functions;
-      console.log(funcObjectArray);
-
-      //this controller will return an array of objects with more information than we potentially need
-      //in order to get ONLY a functionsList array, use the following logic
-      let functionsList = [];
-      for (const func of funcObjectArray){
-        functionsList.push(func.FunctionName);
-      }
-      console.log(functionsList);
-
-      return funcObjectArray;
+        //gather function names into array
+        res.locals.functionsList = [];
+        for (const func of funcObjectArray){
+          res.locals.functionsList.push(func.FunctionName);
+        }
+        // console.log('functionsList: ', res.locals.functionsList);
+    
+        return next();
     } catch (err) {
-      console.error(err);
+        //need to insert global error handler with return next({error})
+        console.error(err);
+    }
     }
 };
-
-//in order to run this file, make your directory the "controllers" folder (i.e. cd server && cd controllers)
-//then input the command ts-node getFunctionsController.ts
-getFunctions();

--- a/server/controllers/getFunctionsController.ts
+++ b/server/controllers/getFunctionsController.ts
@@ -33,6 +33,7 @@ export const getFunctionsController: GetFunctionsController = {
     } catch (err) {
         //need to insert global error handler with return next({error})
         console.error(err);
+        return next({err});
     }
     }
 };

--- a/server/controllers/lambdaController.ts
+++ b/server/controllers/lambdaController.ts
@@ -5,7 +5,7 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 // Define the logGroupName to fetch the logs from aws
-const logGroupName = '/aws/lambda/testfunc'; 
+const logGroupName = '/aws/lambda/test-metric-pull-2'; 
 
 // Define the environment variables and access token in .env file
 const region = process.env.AWS_REGION as string;

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@types/express": "^4.17.21",
+        "@types/node": "^22.5.0",
         "nodemon": "^3.1.4",
         "typescript": "^5.5.4"
       }
@@ -1750,10 +1751,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.4.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.4.1.tgz",
-      "integrity": "sha512-1tbpb9325+gPnKK0dMm+/LMriX0vKxf6RnB0SZUqfyVkQ4fMgUSySqhxE/y8Jvs4NyF1yHzTfG9KlnkIODxPKg==",
-      "license": "MIT",
+      "version": "22.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.0.tgz",
+      "integrity": "sha512-DkFrJOe+rfdHTqqMg0bSNlGlQ85hSoh2TPzZyhHsXnMtligRWpxUySiyw8FY14ITt24HVCiQPWxS3KO/QlGmWg==",
       "dependencies": {
         "undici-types": "~6.19.2"
       }

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/node": "^22.5.0",
     "nodemon": "^3.1.4",
     "typescript": "^5.5.4"
   }

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,5 +1,7 @@
 import express, { NextFunction, Request, Response } from 'express';
 import { getLogs } from './controllers/lambdaController';
+import { getFunctionsController } from './controllers/getFunctionsController';
+import { get } from 'http';
 
 const app = express();
 
@@ -11,6 +13,13 @@ getLogs().then(() => {
   console.log('Log fetching completed');
 }).catch(err => {
   console.log('Error fetching logs:', err.message)
+})
+
+
+//to test, run npm start in the server direcotry then send a postman request to localhost:8080/api
+app.get('/api', getFunctionsController.listFunctionData, (_req: Request, res: Response, _next: NextFunction) => {
+  console.log('res.locals.functionsList from server.ts: ', res.locals.functionsList);
+  res.send(res.locals.functionsList);
 })
 
 app.get('/', (req: Request, res: Response, next: NextFunction) => {

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,21 +1,18 @@
 import express, { NextFunction, Request, Response } from 'express';
 import { getLogs } from './controllers/lambdaController';
 import configRoutes from './routes/configRoutes';
-const cors = require('cors');
-
-
 import { getFunctionsController } from './controllers/getFunctionsController';
 import { get } from 'http';
 
 const app = express();
+const cors = require('cors');
 
 const PORT = 8080;
 
 app.use(express.json());
 app.use(cors());
 
-// Configuration router
-console.log('Config route confirmation')
+
 app.use('/api/config', configRoutes);
 
 // call func getLogs to perform async 
@@ -31,7 +28,7 @@ getLogs().then(() => {
 //to test, run npm start in the server direcotry then send a postman request to localhost:8080/api
 app.get('/api', getFunctionsController.listFunctionData, (_req: Request, res: Response, _next: NextFunction) => {
   console.log('res.locals.functionsList from server.ts: ', res.locals.functionsList);
-  res.send(res.locals.functionsList);
+  res.status(200).send(res.locals.functionsList);
 })
 
 app.get('/', (req: Request, res: Response, next: NextFunction) => {

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -106,10 +106,15 @@
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
   "include": [
-    "**/*.ts"
-, "../types.ts"  ],
+    "**/*.ts",
+    "types.ts",
+    ".env"  
+  ],
   "exclude": [
     "node_modules",
     "dist"
-  ]
+  ],  
+  "ts-node": {
+    "files": true
+  },
 }

--- a/server/types.ts
+++ b/server/types.ts
@@ -1,7 +1,7 @@
-export interface Config {
+export type Config = {
+  region: string;
     credentials: {
       accessKeyId: string;
       secretAccessKey: string;
     };
-    region: string;
   };


### PR DESCRIPTION
## Linked issue/ticket

<!-- Jira Ticket -->
[https://lambdalens.atlassian.net/browse/SCRUM-39](https://lambdalens.atlassian.net/browse/SCRUM-39)

## Description
1. Converted /server/controllers/getFunctionsController.ts from vanilla javascript to typescript and cleaned it up a bit
2. Made the exported module an object with method listFunctionData to be called as middleware instead of previously exporting the function itself that returned an object.
3. Moved the types.ts file into the server folder
4. Added a configs folder with awsconfig.ts inside



## Reproduction steps

<!-- Include step-by-step instructions on how to reproduce and test this ticket. -->
To test the getFunctionsController middleware method listFunctionData, run npm start in the server directory then send a postman request to localhost:8080/api. The terminal should console.log an array of all Lambda function names for the provided aws user and it should be sent as a response as well. 

## Work in progress
1. Probably need to change the endpoint in the server.ts file and use a router 
2. Need to add better error handling, more detailed error object to pass into next({err}) in getFunctionsController.ts